### PR TITLE
Param for lowering used channel count

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,7 @@ You can also optionally specify:
 * ``lidar_mode:=<mode>`` where mode is one of ``512x10``, ``512x20``, ``1024x10``, ``1024x20``, or
   ``2048x10``, and
 * ``viz:=true`` to visualize the sensor output, if you have the rviz ROS package installed
+* ``channel_reduction_ratio:=<int>`` to reduce the amount of channels used for the output cloud. So a 128 beam lidar with a channel_reduction_ratio of 4 would result in a simulated 32 beam lidar. (Value has to be 2^n)
 
 
 Recording Data

--- a/ouster_ros/include/ouster_ros/ros.h
+++ b/ouster_ros/include/ouster_ros/ros.h
@@ -63,10 +63,11 @@ sensor_msgs::Imu packet_to_imu_msg(const PacketMsg& pm,
  * @param ls input lidar data
  * @param return_index index of return desired starting at 0
  * @param cloud output pcl pointcloud to populate
+ * @param channel_reduction_ratio ratio at which to reduce channel count
  */
 void scan_to_cloud(const ouster::XYZLut& xyz_lut,
                    ouster::LidarScan::ts_t scan_ts, const ouster::LidarScan& ls,
-                   ouster_ros::Cloud& cloud, int return_index = 0);
+                   ouster_ros::Cloud& cloud, uint32_t channel_reduction_ratio, int return_index = 0);
 
 /**
  * Serialize a PCL point cloud to a ROS message

--- a/ouster_ros/ouster.launch
+++ b/ouster_ros/ouster.launch
@@ -12,6 +12,7 @@
   <arg name="rviz_config" default="-d $(find ouster_ros)/viz.rviz" doc="optional rviz config file"/>
   <arg name="tf_prefix" default="" doc="namespace for tf transforms"/>
   <arg name="udp_profile_lidar" default="" doc="lidar packet profile: LEGACY, RNG19_RFL8_SIG16_NIR16_DUAL"/>
+  <arg name="channel_reduction_ratio" default="1" doc="the ratio at wich to reduce channel count, can be used to simulate a lower beam count lidar (VALUE MUST BE 2^n)"/>
 
   <node pkg="ouster_ros" name="os_node" type="os_node" output="screen" required="true">
     <param name="~/lidar_mode" type="string" value="$(arg lidar_mode)"/>
@@ -30,6 +31,7 @@
     <remap from="~/lidar_packets" to="/os_node/lidar_packets"/>
     <remap from="~/imu_packets" to="/os_node/imu_packets"/>
     <param name="~/tf_prefix" value="$(arg tf_prefix)"/>
+    <param name="~/channel_reduction_ratio" value="$(arg channel_reduction_ratio)"/>
   </node>
 
   <node if="$(arg viz)" pkg="rviz" name="rviz" type="rviz" args="$(arg rviz_config)" output="screen" required="true" />

--- a/ouster_ros/ouster.launch
+++ b/ouster_ros/ouster.launch
@@ -34,6 +34,12 @@
     <param name="~/channel_reduction_ratio" value="$(arg channel_reduction_ratio)"/>
   </node>
 
+  <node pkg="ouster_ros" type="img_node" name="img_node" output="screen" required="false">
+    <remap from="~/os_config" to="/os_node/os_config"/>
+    <remap from="~/points" to="/os_cloud_node/points"/>
+    <param name="~/channel_reduction_ratio" value="$(arg channel_reduction_ratio)"/>
+  </node>
+
   <node if="$(arg viz)" pkg="rviz" name="rviz" type="rviz" args="$(arg rviz_config)" output="screen" required="true" />
   <node if="$(arg viz)" pkg="ouster_ros" name="img_node" type="img_node" output="screen" required="true">
     <remap from="~/os_config" to="/os_node/os_config"/>

--- a/ouster_ros/src/img_node.cpp
+++ b/ouster_ros/src/img_node.cpp
@@ -52,6 +52,8 @@ int main(int argc, char** argv) {
     ros::init(argc, argv, "img_node");
     ros::NodeHandle nh("~");
 
+    uint32_t channel_reduction_ratio = nh.param("channel_reduction_ratio", 1);
+
     ouster_ros::OSConfigSrv cfg{};
     auto client = nh.serviceClient<ouster_ros::OSConfigSrv>("os_config");
     client.waitForExistence();
@@ -61,7 +63,7 @@ int main(int argc, char** argv) {
     }
 
     auto info = sensor::parse_metadata(cfg.response.metadata);
-    size_t H = info.format.pixels_per_column;
+    size_t H = info.format.pixels_per_column / channel_reduction_ratio;
     size_t W = info.format.columns_per_frame;
 
     auto udp_profile_lidar = info.format.udp_profile_lidar;

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -6,6 +6,7 @@
 #include <ros/console.h>
 #include <ros/ros.h>
 #include <ros/service.h>
+#include <ros/assert.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <tf2_ros/static_transform_broadcaster.h>
@@ -13,6 +14,7 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <cassert>
 
 #include "ouster/lidar_scan.h"
 #include "ouster/types.h"
@@ -28,6 +30,8 @@ namespace sensor = ouster::sensor;
 int main(int argc, char** argv) {
     ros::init(argc, argv, "os_cloud_node");
     ros::NodeHandle nh("~");
+
+    uint32_t channel_reduction_ratio = nh.param("channel_reduction_ratio", 1);
 
     auto tf_prefix = nh.param("tf_prefix", std::string{});
     if (!tf_prefix.empty() && tf_prefix.back() != '/') tf_prefix.append("/");
@@ -47,6 +51,15 @@ int main(int argc, char** argv) {
     uint32_t H = info.format.pixels_per_column;
     uint32_t W = info.format.columns_per_frame;
     auto udp_profile_lidar = info.format.udp_profile_lidar;
+
+    if(channel_reduction_ratio != 1){
+        if(channel_reduction_ratio <= 0) 
+            throw std::invalid_argument("channel_reduction_ratio must be greater than zero");
+        if(H <= channel_reduction_ratio)
+            throw std::invalid_argument("channel_reduction_ratio must be less than or equal to the lidar channel count");
+        if(ceil(log2(channel_reduction_ratio)) != floor(log2(channel_reduction_ratio))) 
+            throw std::invalid_argument("channel_reduction_ratio must be 2^n");
+    }
 
     const int n_returns =
         (udp_profile_lidar == sensor::UDPProfileLidar::PROFILE_LIDAR_LEGACY)
@@ -71,7 +84,7 @@ int main(int argc, char** argv) {
     auto xyz_lut = ouster::make_xyz_lut(info);
 
     ouster::LidarScan ls{W, H, udp_profile_lidar};
-    Cloud cloud{W, H};
+    Cloud cloud{W, H / channel_reduction_ratio};
 
     ouster::ScanBatcher batch(W, pf);
 
@@ -83,7 +96,7 @@ int main(int argc, char** argv) {
                 });
             if (h != ls.headers.end()) {
                 for (int i = 0; i < n_returns; i++) {
-                    scan_to_cloud(xyz_lut, h->timestamp, ls, cloud, i);
+                    scan_to_cloud(xyz_lut, h->timestamp, ls, cloud, channel_reduction_ratio, i);
                     lidar_pubs[i].publish(ouster_ros::cloud_to_cloud_msg(
                         cloud, h->timestamp, sensor_frame));
                 }

--- a/ouster_ros/src/os_cloud_node.cpp
+++ b/ouster_ros/src/os_cloud_node.cpp
@@ -6,7 +6,6 @@
 #include <ros/console.h>
 #include <ros/ros.h>
 #include <ros/service.h>
-#include <ros/assert.h>
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <tf2_ros/static_transform_broadcaster.h>
@@ -14,7 +13,6 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
-#include <cassert>
 
 #include "ouster/lidar_scan.h"
 #include "ouster/types.h"


### PR DESCRIPTION
Created a paramater so it is possible to reduce the amount of channels used for the output cloud. Can be used to simulate lidars with lower beam count.