### PR TITLE
add azimuth window config support

### DIFF
--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -57,6 +57,26 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     int timeout_sec = 60);
 
 /**
+ * Connect to and configure the sensor and start listening for data.
+ *
+ * @param hostname hostname or ip of the sensor
+ * @param udp_dest_host hostname or ip where the sensor should send data
+ * or "" for automatic detection of destination
+ * @param azimuth_window azimuth window the sensor will send back the data
+ * @param lidar_port port on which the sensor will send lidar data
+ * @param imu_port port on which the sensor will send imu data
+ * @param timeout_sec how long to wait for the sensor to initialize
+ * @return pointer owning the resources associated with the connection
+ */
+std::shared_ptr<client> init_client(const std::string& hostname,
+                                    const std::string& udp_dest_host,
+                                    lidar_mode mode = MODE_UNSPEC,
+                                    timestamp_mode ts_mode = TIME_FROM_UNSPEC,
+                                    AzimuthWindow azimuth_window = {0, 360000},
+                                    int lidar_port = 0, int imu_port = 0,
+                                    int timeout_sec = 60);
+
+/**
  * Block for up to timeout_sec until either data is ready or an error occurs.
  *
  * NOTE: will return immediately if LIDAR_DATA or IMU_DATA are set and not

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -44,24 +44,6 @@ std::shared_ptr<client> init_client(const std::string& hostname = "",
  * @param hostname hostname or ip of the sensor
  * @param udp_dest_host hostname or ip where the sensor should send data
  * or "" for automatic detection of destination
- * @param lidar_port port on which the sensor will send lidar data
- * @param imu_port port on which the sensor will send imu data
- * @param timeout_sec how long to wait for the sensor to initialize
- * @return pointer owning the resources associated with the connection
- */
-std::shared_ptr<client> init_client(const std::string& hostname,
-                                    const std::string& udp_dest_host,
-                                    lidar_mode mode = MODE_UNSPEC,
-                                    timestamp_mode ts_mode = TIME_FROM_UNSPEC,
-                                    int lidar_port = 0, int imu_port = 0,
-                                    int timeout_sec = 60);
-
-/**
- * Connect to and configure the sensor and start listening for data.
- *
- * @param hostname hostname or ip of the sensor
- * @param udp_dest_host hostname or ip where the sensor should send data
- * or "" for automatic detection of destination
  * @param azimuth_window azimuth window the sensor will send back the data
  * @param lidar_port port on which the sensor will send lidar data
  * @param imu_port port on which the sensor will send imu data
@@ -72,9 +54,9 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     const std::string& udp_dest_host,
                                     lidar_mode mode = MODE_UNSPEC,
                                     timestamp_mode ts_mode = TIME_FROM_UNSPEC,
-                                    AzimuthWindow azimuth_window = {0, 360000},
                                     int lidar_port = 0, int imu_port = 0,
-                                    int timeout_sec = 60);
+                                    int timeout_sec = 60, 
+                                    AzimuthWindow azimuth_window = {0, 360000});
 
 /**
  * Block for up to timeout_sec until either data is ready or an error occurs.

--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -283,6 +283,14 @@ std::string to_string(NMEABaudRate rate);
 optional<NMEABaudRate> nmea_baud_rate_of_string(const std::string& s);
 
 /**
+ * Get azimuth window from string.
+ *
+ * @param string
+ * @return azimuth window corresponding to the string, or 0 on error
+ */
+optional<AzimuthWindow> azimuth_window_of_string(const std::string& s);
+
+/**
  * Get string representation of an Azimuth Window
  *
  * @param azimuth_window

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -456,96 +456,13 @@ std::shared_ptr<client> init_client(const std::string& hostname, int lidar_port,
     return cli;
 }
 
-std::shared_ptr<client> init_client(const std::string& hostname,
-                                    const std::string& udp_dest_host,
-                                    lidar_mode mode, timestamp_mode ts_mode,
-                                    int lidar_port, int imu_port,
-                                    int timeout_sec) {
-    auto cli = init_client(hostname, lidar_port, imu_port);
-    if (!cli) return std::shared_ptr<client>();
-
-    // update requested ports to actual bound ports
-    lidar_port = get_sock_port(cli->lidar_fd);
-    imu_port = get_sock_port(cli->imu_fd);
-    if (!impl::socket_valid(lidar_port) || !impl::socket_valid(imu_port))
-        return std::shared_ptr<client>();
-
-    SOCKET sock_fd = cfg_socket(hostname.c_str());
-    if (!impl::socket_valid(sock_fd)) return std::shared_ptr<client>();
-
-    std::string res;
-    bool success = true;
-
-    // fail fast if we can't reach the sensor via TCP
-    success &= do_tcp_cmd(sock_fd, {"get_sensor_info"}, res);
-    if (!success) {
-        impl::socket_close(sock_fd);
-        return std::shared_ptr<client>();
-    }
-
-    // if dest address is not specified, have the sensor to set it automatically
-    if (udp_dest_host == "") {
-        success &= do_tcp_cmd(sock_fd, {"set_udp_dest_auto"}, res);
-        success &= res == "set_udp_dest_auto";
-    } else {
-        success &= do_tcp_cmd(
-            sock_fd, {"set_config_param", "udp_ip", udp_dest_host}, res);
-        success &= res == "set_config_param";
-    }
-
-    success &= do_tcp_cmd(
-        sock_fd,
-        {"set_config_param", "udp_port_lidar", std::to_string(lidar_port)},
-        res);
-    success &= res == "set_config_param";
-
-    success &= do_tcp_cmd(
-        sock_fd, {"set_config_param", "udp_port_imu", std::to_string(imu_port)},
-        res);
-    success &= res == "set_config_param";
-
-    // if specified (not UNSPEC), set the lidar and timestamp modes
-    if (mode) {
-        success &= do_tcp_cmd(
-            sock_fd, {"set_config_param", "lidar_mode", to_string(mode)}, res);
-        success &= res == "set_config_param";
-    }
-
-    if (ts_mode) {
-        success &= do_tcp_cmd(
-            sock_fd, {"set_config_param", "timestamp_mode", to_string(ts_mode)},
-            res);
-        success &= res == "set_config_param";
-    }
-
-    // wake up from STANDBY, if necessary
-    success &=
-        do_tcp_cmd(sock_fd, {"set_config_param", "auto_start_flag", "1"}, res);
-    success &= res == "set_config_param";
-
-    // reinitialize to activate new settings
-    success &= do_tcp_cmd(sock_fd, {"reinitialize"}, res);
-    success &= res == "reinitialize";
-
-    // will block until no longer INITIALIZING
-    success &= collect_metadata(*cli, sock_fd, chrono::seconds{timeout_sec});
-
-    // check for sensor error states
-    auto status = cli->meta["sensor_info"]["status"].asString();
-    success &= (status != "ERROR" && status != "UNCONFIGURED");
-
-    impl::socket_close(sock_fd);
-
-    return success ? cli : std::shared_ptr<client>();
-}
-
 std::shared_ptr<client> init_client(
   const std::string & hostname,
   const std::string & udp_dest_host,
   lidar_mode mode, timestamp_mode ts_mode,
-  AzimuthWindow azimuth_window,
   int lidar_port, int imu_port,
-  int timeout_sec)
+  int timeout_sec,
+  AzimuthWindow azimuth_window)
 {
     auto cli = init_client(hostname, lidar_port, imu_port);
     if (!cli) {return std::shared_ptr<client>();}

--- a/ouster_client/src/types.cpp
+++ b/ouster_client/src/types.cpp
@@ -364,6 +364,13 @@ optional<NMEABaudRate> nmea_baud_rate_of_string(const std::string& s) {
     return rlookup(impl::nmea_baud_rate_strings, s.c_str());
 }
 
+optional<AzimuthWindow> azimuth_window_of_string(const std::string& s) 
+{
+  AzimuthWindow p;
+  int res = sscanf(s.c_str(),"[%i,%i]",&p.first,&p.second);
+  return res == 2 ? make_optional<AzimuthWindow>(p) : nullopt;
+}
+
 std::string to_string(AzimuthWindow azimuth_window) {
     std::stringstream ss;
     ss << "[" << azimuth_window.first << ", " << azimuth_window.second << "]";


### PR DESCRIPTION
Recent versions of the ouster FW seem to reset the azimuth windows on reboot. Therefore I am trying to add the azimuth as a possible configuration on the start of the ROS2 driver. For that reason I need to add that as a configuration in here.

I have tested it to be working with the OS1-64 FW 2.2.1 with the ROS2 driver in foxy. I replicated the same changes here.