### PR TITLE
Modified representations_example to getting IMU data from pcap and display

### DIFF
--- a/examples/representations_example.cpp
+++ b/examples/representations_example.cpp
@@ -169,6 +169,7 @@ int main(int argc, char* argv[]) {
               << std::endl;
 
     // 5. getting IMU
+    std::cerr << "\n5. Getting IMU data..." << std::endl;
     sensor::packet_format pf = sensor::get_format(info);
     ouster::sensor_utils::read_packet(*handle, packet_buf.get(), UDP_BUF_SIZE);
     std::cout << "IMU Timestamp: " << pf.imu_gyro_ts(packet_buf.get()) << " ns" << std::endl;

--- a/examples/representations_example.cpp
+++ b/examples/representations_example.cpp
@@ -20,6 +20,9 @@
 
 using namespace ouster;
 
+const size_t UDP_BUF_SIZE = 65536;
+auto packet_buf = std::make_unique<uint8_t[]>(UDP_BUF_SIZE);
+
 //! [docs-stag-x-image-form]
 img_t<double> get_x_in_image_form(const LidarScan& scan, bool destaggered,
                                   const sensor::sensor_info& info) {
@@ -164,4 +167,27 @@ int main(int argc, char* argv[]) {
               << " and an x coordinate of "
               << x_image_destaggered(print_row, print_column) << "."
               << std::endl;
+
+    // 5. getting IMU
+    sensor::packet_format pf = sensor::get_format(info);
+    ouster::sensor_utils::read_packet(*handle, packet_buf.get(), UDP_BUF_SIZE);
+    std::cout << "IMU Timestamp: " << pf.imu_gyro_ts(packet_buf.get()) << " ns" << std::endl;
+
+    const double standard_g = 9.80665;
+    auto linear_acceleration_x = pf.imu_la_x(packet_buf.get()) * standard_g;
+    auto linear_acceleration_y = pf.imu_la_y(packet_buf.get()) * standard_g;
+    auto linear_acceleration_z = pf.imu_la_z(packet_buf.get()) * standard_g;
+
+    auto angular_velocity_x = pf.imu_av_x(packet_buf.get()) * M_PI / 180.0;
+    auto angular_velocity_y = pf.imu_av_y(packet_buf.get()) * M_PI / 180.0;
+    auto angular_velocity_z = pf.imu_av_z(packet_buf.get()) * M_PI / 180.0;
+
+    std::cerr << "IMU Acceleration: [" 
+                << linear_acceleration_x << ", "
+                << linear_acceleration_y << ", "
+                << linear_acceleration_z << "] G" << std::endl;
+    std::cerr << "IMU Angular Velocity: [" 
+                << angular_velocity_x << ", "
+                << angular_velocity_y << ", "
+                << angular_velocity_z << "] deg/s" << std::endl;
 }


### PR DESCRIPTION
## Summary of Changes

- Added functionality to display IMU data alongside lidar data processing in the representations_example.cpp.

## Validation

- Successfully read the pcap and json files and display output as below:

```sh
Reading in scan from pcap...
1. Calculating 3d Points... 

Let's see what the 2000th point in this cloud is...  (-0, -0, 0)
2. Now we will apply this transformation to the look-up table:
     -1       0       0    1500
      0       1       0       0
      0       0      -1 19961.8
      0       0       0       1
Calculating 3d Points of with special transform provided..
And now the 2000th point in the transformed point cloud... (-0, 0, -0)

3. Getting staggered and destaggered images of Reflectivity...
4. Getting staggered and destaggered images of X Coordinate...
In the staggered image, the point at (123, 517) has reflectivity 0 and an x coordinate of 0.
In the destagged image, the point at (123, 517) has reflectivity 0 and an x coordinate of 0.

5. Getting IMU data...
IMU Timestamp: 0 ns
IMU Acceleration: [0, 0, 2.46256e+08] G
IMU Angular Velocity: [2.49464e-45, 1.60283e-42, 0] deg/s
```
