### PR TITLE
Option to set operating mode at init_client

### DIFF
--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -89,10 +89,10 @@ std::shared_ptr<client> init_client(const std::string& hostname, int lidar_port,
  * using zero the method will automatically acquire and assign any free port.
  * @param[in] imu_port port on which the sensor will send imu data. When
  * using zero the method will automatically acquire and assign any free port.
- * method will leave the sensor in its current operating mode.
  * @param[in] timeout_sec how long to wait for the sensor to initialize.
  * @param[in] persist_config if true, persists sensor settings between restarts
  * @param[in] operating_mode The lidar operating mode. When using zero the
+ * method will leave the sensor in its current operating mode.
  *
  * @return pointer owning the resources associated with the connection.
  */

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -98,6 +98,7 @@ std::shared_ptr<client> init_client(
     const std::string& hostname, const std::string& udp_dest_host,
     lidar_mode ld_mode = MODE_UNSPEC, timestamp_mode ts_mode = TIME_FROM_UNSPEC,
     int lidar_port = 0, int imu_port = 0,
+    OperatingMode operating_mode = OPERATING_NORMAL,
     int timeout_sec = LONG_HTTP_REQUEST_TIMEOUT_SECONDS,
     bool persist_config = false);
 

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -89,6 +89,8 @@ std::shared_ptr<client> init_client(const std::string& hostname, int lidar_port,
  * using zero the method will automatically acquire and assign any free port.
  * @param[in] imu_port port on which the sensor will send imu data. When
  * using zero the method will automatically acquire and assign any free port.
+ * @param[in] operating_mode The lidar operating mode. When using zero the
+ * method will leave the sensor in its current operating mode.
  * @param[in] timeout_sec how long to wait for the sensor to initialize.
  * @param[in] persist_config if true, persists sensor settings between restarts
  *

--- a/ouster_client/include/ouster/client.h
+++ b/ouster_client/include/ouster/client.h
@@ -89,10 +89,10 @@ std::shared_ptr<client> init_client(const std::string& hostname, int lidar_port,
  * using zero the method will automatically acquire and assign any free port.
  * @param[in] imu_port port on which the sensor will send imu data. When
  * using zero the method will automatically acquire and assign any free port.
- * @param[in] operating_mode The lidar operating mode. When using zero the
  * method will leave the sensor in its current operating mode.
  * @param[in] timeout_sec how long to wait for the sensor to initialize.
  * @param[in] persist_config if true, persists sensor settings between restarts
+ * @param[in] operating_mode The lidar operating mode. When using zero the
  *
  * @return pointer owning the resources associated with the connection.
  */
@@ -100,9 +100,9 @@ std::shared_ptr<client> init_client(
     const std::string& hostname, const std::string& udp_dest_host,
     lidar_mode ld_mode = MODE_UNSPEC, timestamp_mode ts_mode = TIME_FROM_UNSPEC,
     int lidar_port = 0, int imu_port = 0,
-    OperatingMode operating_mode = OPERATING_NORMAL,
     int timeout_sec = LONG_HTTP_REQUEST_TIMEOUT_SECONDS,
-    bool persist_config = false);
+    bool persist_config = false,
+    OperatingMode operating_mode = OPERATING_NORMAL);
 
 /**
  * [BETA] Connect to and configure the sensor and start listening for data via

--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -565,7 +565,7 @@ struct sensor_info {
     std::string user_data{};    ///< userdata from sensor if available
 
     /* Constructor from metadata */
-    [[deprecated("skip_beam_validation does not do anything anymore")]]
+    [[deprecated("skip_beam_validation does not do anything anymore")]] 
         explicit sensor_info(const std::string& metadata, bool skip_beam_validation);
     explicit sensor_info(const std::string& metadata);
 
@@ -576,7 +576,7 @@ struct sensor_info {
      * changes to the sensor_info.
      * Errors out if changes are incompatible but does not check for validity */
     std::string to_json_string() const;
-
+    
     /**
      * Parse and return version info about this sensor.
      *
@@ -1026,7 +1026,7 @@ namespace ChanField {
                           ///< sensitivity in FW 2.1+. See sensor docs for more details
     static constexpr cf_type REFLECTIVITY2 = "REFLECTIVITY2";    ///< 2nd return reflectivity, calibrated by range and sensor
                           ///< sensitivity in FW 2.1+. See sensor docs for more details
-
+    
     static constexpr cf_type NEAR_IR = "NEAR_IR";          ///< near_ir in photons
     static constexpr cf_type FLAGS = "FLAGS";            ///< 1st return flags
     static constexpr cf_type FLAGS2 = "FLAGS2";           ///< 2nd return flags

--- a/ouster_client/include/ouster/types.h
+++ b/ouster_client/include/ouster/types.h
@@ -100,7 +100,8 @@ enum timestamp_mode {
  * meaning of each option.
  */
 enum OperatingMode {
-    OPERATING_NORMAL = 1,  ///< Normal sensor operation
+    OPERATING_UNSPEC = 0,  ///< Unspecified sensor operation
+    OPERATING_NORMAL,      ///< Normal sensor operation
     OPERATING_STANDBY      ///< Standby
 };
 
@@ -564,7 +565,7 @@ struct sensor_info {
     std::string user_data{};    ///< userdata from sensor if available
 
     /* Constructor from metadata */
-    [[deprecated("skip_beam_validation does not do anything anymore")]] 
+    [[deprecated("skip_beam_validation does not do anything anymore")]]
         explicit sensor_info(const std::string& metadata, bool skip_beam_validation);
     explicit sensor_info(const std::string& metadata);
 
@@ -575,7 +576,7 @@ struct sensor_info {
      * changes to the sensor_info.
      * Errors out if changes are incompatible but does not check for validity */
     std::string to_json_string() const;
-    
+
     /**
      * Parse and return version info about this sensor.
      *
@@ -1025,7 +1026,7 @@ namespace ChanField {
                           ///< sensitivity in FW 2.1+. See sensor docs for more details
     static constexpr cf_type REFLECTIVITY2 = "REFLECTIVITY2";    ///< 2nd return reflectivity, calibrated by range and sensor
                           ///< sensitivity in FW 2.1+. See sensor docs for more details
-    
+
     static constexpr cf_type NEAR_IR = "NEAR_IR";          ///< near_ir in photons
     static constexpr cf_type FLAGS = "FLAGS";            ///< 1st return flags
     static constexpr cf_type FLAGS2 = "FLAGS2";           ///< 2nd return flags

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -382,6 +382,7 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     const std::string& udp_dest_host,
                                     lidar_mode ld_mode, timestamp_mode ts_mode,
                                     int lidar_port, int imu_port,
+                                    OperatingMode operating_mode,
                                     int timeout_sec, bool persist_config) {
     auto cli = init_client(hostname, lidar_port, imu_port);
     if (!cli) return std::shared_ptr<client>();
@@ -406,7 +407,7 @@ std::shared_ptr<client> init_client(const std::string& hostname,
         if (lidar_port) config.udp_port_lidar = lidar_port;
         if (imu_port) config.udp_port_imu = imu_port;
         if (persist_config) config_flags |= CONFIG_PERSIST;
-        config.operating_mode = OPERATING_NORMAL;
+        if (operating_mode) config.operating_mode = OPERATING_NORMAL;
         set_config(*sensor_http, config, config_flags, timeout_sec);
 
         // will block until no longer INITIALIZING

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -407,7 +407,7 @@ std::shared_ptr<client> init_client(const std::string& hostname,
         if (lidar_port) config.udp_port_lidar = lidar_port;
         if (imu_port) config.udp_port_imu = imu_port;
         if (persist_config) config_flags |= CONFIG_PERSIST;
-        if (operating_mode) config.operating_mode = OPERATING_NORMAL;
+        if (operating_mode) config.operating_mode = operating_mode;
         set_config(*sensor_http, config, config_flags, timeout_sec);
 
         // will block until no longer INITIALIZING

--- a/ouster_client/src/client.cpp
+++ b/ouster_client/src/client.cpp
@@ -382,8 +382,8 @@ std::shared_ptr<client> init_client(const std::string& hostname,
                                     const std::string& udp_dest_host,
                                     lidar_mode ld_mode, timestamp_mode ts_mode,
                                     int lidar_port, int imu_port,
-                                    OperatingMode operating_mode,
-                                    int timeout_sec, bool persist_config) {
+                                    int timeout_sec, bool persist_config,
+                                    OperatingMode operating_mode) {
     auto cli = init_client(hostname, lidar_port, imu_port);
     if (!cli) return std::shared_ptr<client>();
     logger().info("(0 means a random port will be chosen)");


### PR DESCRIPTION
## Related Issues & PRs
None

## Summary of Changes
Modified the `init_client` function that connects and configures a sensor to allow to set the operating_mode at boot and not have a forced `OPERATING_NORMAL`

## Validation
```
Running tests...
Test project /home/blebreton/svn/rtp/external/ouster-sdk/build/Release
      Start  1: osf_png_tools_test
 1/25 Test  #1: osf_png_tools_test ...............   Passed    2.49 sec
      Start  2: osf_writer_test
 2/25 Test  #2: osf_writer_test ..................   Passed    3.03 sec
      Start  3: osf_writerv2_test
 3/25 Test  #3: osf_writerv2_test ................   Passed    0.39 sec
      Start  4: osf_writer_custom_test
 4/25 Test  #4: osf_writer_custom_test ...........   Passed    0.00 sec
      Start  5: osf_file_test
 5/25 Test  #5: osf_file_test ....................   Passed    0.01 sec
      Start  6: osf_crc_test
 6/25 Test  #6: osf_crc_test .....................   Passed    0.00 sec
      Start  7: osf_file_ops_test
 7/25 Test  #7: osf_file_ops_test ................   Passed    0.00 sec
      Start  8: osf_reader_test
 8/25 Test  #8: osf_reader_test ..................   Passed    0.01 sec
      Start  9: osf_operations_test
 9/25 Test  #9: osf_operations_test ..............   Passed    0.03 sec
      Start 10: osf_basics_test
10/25 Test #10: osf_basics_test ..................   Passed    0.00 sec
      Start 11: osf_meta_streaming_info_test
11/25 Test #11: osf_meta_streaming_info_test .....   Passed    0.00 sec
      Start 12: bcompat_meta_json_test
12/25 Test #12: bcompat_meta_json_test ...........   Passed    0.07 sec
      Start 13: metadata_test
13/25 Test #13: metadata_test ....................   Passed    0.06 sec
      Start 14: lidar_scan_test
14/25 Test #14: lidar_scan_test ..................   Passed    0.07 sec
      Start 15: cartesian_test
15/25 Test #15: cartesian_test ...................   Passed    8.73 sec
      Start 16: metadata_errors_test
16/25 Test #16: metadata_errors_test .............   Passed    0.01 sec
      Start 17: pcap_test
17/25 Test #17: pcap_test ........................   Passed    0.06 sec
      Start 18: profile_extension_test
18/25 Test #18: profile_extension_test ...........   Passed    0.00 sec
      Start 19: fusa_profile_test
19/25 Test #19: fusa_profile_test ................   Passed    0.01 sec
      Start 20: parsing_benchmark_test
20/25 Test #20: parsing_benchmark_test ...........   Passed   16.69 sec
      Start 21: scan_batcher_test
21/25 Test #21: scan_batcher_test ................   Passed    0.25 sec
      Start 22: packet_writer_test
22/25 Test #22: packet_writer_test ...............   Passed    0.23 sec
      Start 23: array_view_test
23/25 Test #23: array_view_test ..................   Passed    0.56 sec
      Start 24: field_test
24/25 Test #24: field_test .......................   Passed    0.14 sec
      Start 25: point_viz_test
25/25 Test #25: point_viz_test ...................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 25

Total Test time (real) =  32.85 sec
```