### PR TITLE
Add missing cassert header

### DIFF
--- a/ouster_client/include/ouster/impl/lidar_scan_impl.h
+++ b/ouster_client/include/ouster/impl/lidar_scan_impl.h
@@ -8,6 +8,7 @@
 #include <Eigen/Core>
 #include <cstdint>
 #include <stdexcept>
+#include <cassert>
 
 #include "ouster/field.h"
 #include "ouster/impl/packet_writer.h"


### PR DESCRIPTION
Fix build issue `error: ‘assert’ was not declared in this scope` due to missing header "cassert" in the lidar_scan_impl.h or any included header

```cpp
/tmp/ouster_ws/src/ouster-ros/ouster-sdk/ouster_client/include/ouster/impl/lidar_scan_impl.h: In function ‘bool ouster::impl::operator==(const ouster::impl::FieldSlot&, const ouster::impl::FieldSlot&)’:
/tmp/ouster_ws/src/ouster-ros/ouster-sdk/ouster_client/include/ouster/impl/lidar_scan_impl.h:141:17: error: ‘assert’ was not declared in this scope
  141 |                 assert(false);
      |                 ^~~~~~
/tmp/ouster_ws/src/ouster-ros/ouster-sdk/ouster_client/include/ouster/impl/lidar_scan_impl.h:13:1: note: ‘assert’ is defined in header ‘<cassert>’; did you forget to ‘#include <cassert>’?
   12 | #include "ouster/impl/packet_writer.h"
  +++ |+#include <cassert>
   13 | #include "ouster/lidar_scan.h"
```

## Related Issues & PRs

## Summary of Changes
Added cassert header in the lidar_scan_impl.h

## Validation
ouster_ros which depends on ouster_sdk should be built without an issue