### PR TITLE
Remove unnecessary include of Eigen/src header

### DIFF
--- a/ouster_client/src/image_processing.cpp
+++ b/ouster_client/src/image_processing.cpp
@@ -5,8 +5,6 @@
 
 #include "ouster/image_processing.h"
 
-#include <Eigen/src/Core/util/Meta.h>
-
 #include <Eigen/Core>
 #include <Eigen/LU>
 #include <algorithm>


### PR DESCRIPTION
We're already `#include`-ing `Eigen/Core` so it is unnecessary to also include `Eigen/src/Core/util/Meta.h`.

Including things from `Eigen/src` causes an error in build systems like Bazel which have strict inclusion checking of a dependency's public headers.

## Related Issues & PRs

## Summary of Changes
Deleted the unnecessary `#include` in ouster_client/src/image_processing.cpp

## Validation
Invoked basic `ouster_client` CMake build.