### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -62,7 +62,7 @@ jobs:
         github-binarycache: true
         revision: 2024.11.16
     - name: cmake configure
-      run: cmake . -B build -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DCMAKE_TOOLCHAIN_FILE=D:/a/ouster-sdk/ouster-sdk/vcpkg/scripts/buildsystems/vcpkg.cmake
+      run: cmake . -B build -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DCMAKE_TOOLCHAIN_FILE=D:/a/ouster-sdk/ouster-sdk/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
     - name: cmake build
       run: cmake --build build -j4
     - name: run tests

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: johnwason/vcpkg-action@v6
       id: vcpkg
       with:
-        pkgs: ${{ github.workspace }}
+        manifest-dir: ${{ github.workspace }}
         triplet: x64-windows
         token: ${{ github.token }}
         github-binarycache: true
@@ -73,7 +73,7 @@ jobs:
       uses: johnwason/vcpkg-action@v6
       id: vcpkg
       with:
-        pkgs: ${{ github.workspace }}
+        manifest-dir: ${{ github.workspace }}
         triplet: x64-windows
         token: ${{ github.token }}
         github-binarycache: true

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: install python-deps one
       run: cd python && python3 setup.py egg_info && pip3 install `grep -v '^\[' src/*.egg-info/requires.txt`
     - name: install python-deps
-      run: pip3 install mypy flake8 clang-format==14.0.0
+      run: pip3 install mypy==1.13.0 flake8 clang-format==14.0.0
     - name: cpp-lint
       run: ./clang-linting.sh
     - name: python-lint

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -53,9 +53,8 @@ jobs:
       uses: johnwason/vcpkg-action@v6
       id: vcpkg
       with:
-        pkgs: eigen3 curl libtins glfw3 libpng flatbuffers gtest
+        pkgs: ${{ github.workspace }}
         triplet: x64-windows
-        revision: 2024.11.16
         token: ${{ github.token }}
         github-binarycache: true
     - name: cmake configure
@@ -74,9 +73,8 @@ jobs:
       uses: johnwason/vcpkg-action@v6
       id: vcpkg
       with:
-        pkgs: eigen3 curl libtins glfw3 libpng flatbuffers gtest
+        pkgs: ${{ github.workspace }}
         triplet: x64-windows
-        revision: 2024.11.16
         token: ${{ github.token }}
         github-binarycache: true
     - name: install python-deps

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: install deps
-      run: sudo apt install build-essential cmake libeigen3-dev libcurl4-openssl-dev libtins-dev libpcap-dev libpng-dev libglfw3-dev libflatbuffers-dev libgtest-dev clang-format
+      run: sudo apt install build-essential cmake libeigen3-dev libcurl4-openssl-dev libtins-dev libpcap-dev libpng-dev libglfw3-dev libflatbuffers-dev libgtest-dev
     - name: cpp-lint
       run: ./clang-linting.sh
     - name: install python
@@ -16,7 +16,7 @@ jobs:
     - name: install python-deps one
       run: cd python && python3 setup.py egg_info && pip3 install `grep -v '^\[' src/*.egg-info/requires.txt`
     - name: install python-deps
-      run: pip3 install mypy flake8
+      run: pip3 install mypy flake8 clang-format==14.0.0
     - name: python-lint
       run: cd python && mypy ./src ./tests ../tests/hil ../tests/integration && flake8
   linux-build:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,7 +1,10 @@
 name: Lint Build and Test
 
-on: [push, pull_request]
-
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: install deps
@@ -20,7 +20,7 @@ jobs:
     - name: python-lint
       run: cd python && mypy ./src ./tests ../tests/hil ../tests/integration && flake8
   linux-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: install deps
@@ -32,7 +32,7 @@ jobs:
     - name: run tests
       run: cd build/ && ctest -j4 --output-on-failure
   linux-python-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v1
     - name: install python

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -9,14 +9,14 @@ jobs:
     - uses: actions/checkout@v1
     - name: install deps
       run: sudo apt install build-essential cmake libeigen3-dev libcurl4-openssl-dev libtins-dev libpcap-dev libpng-dev libglfw3-dev libflatbuffers-dev libgtest-dev
-    - name: cpp-lint
-      run: ./clang-linting.sh
     - name: install python
       run: sudo apt install python3 python3-pip
     - name: install python-deps one
       run: cd python && python3 setup.py egg_info && pip3 install `grep -v '^\[' src/*.egg-info/requires.txt`
     - name: install python-deps
       run: pip3 install mypy flake8 clang-format==14.0.0
+    - name: cpp-lint
+      run: ./clang-linting.sh
     - name: python-lint
       run: cd python && mypy ./src ./tests ../tests/hil ../tests/integration && flake8
   linux-build:

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -57,6 +57,7 @@ jobs:
         triplet: x64-windows
         token: ${{ github.token }}
         github-binarycache: true
+        revision: 2024.11.16
     - name: cmake configure
       run: cmake . -B build -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DCMAKE_TOOLCHAIN_FILE=D:/a/ouster-sdk/ouster-sdk/vcpkg/scripts/buildsystems/vcpkg.cmake
     - name: cmake build
@@ -77,6 +78,7 @@ jobs:
         triplet: x64-windows
         token: ${{ github.token }}
         github-binarycache: true
+        revision: 2024.11.16
     - name: install python-deps
       run: pip3 install pytest pytest-xdist
     - name: build python

--- a/ouster_osf/CMakeLists.txt
+++ b/ouster_osf/CMakeLists.txt
@@ -126,9 +126,10 @@ target_link_libraries(ouster_osf
   PUBLIC
     OusterSDK::ouster_client 
     OusterSDK::ouster_pcap
+    flatbuffers::flatbuffers
   PRIVATE
     PNG::PNG
-    flatbuffers::flatbuffers ZLIB::ZLIB
+    ZLIB::ZLIB
 )
 target_include_directories(ouster_osf PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/ouster_osf/src/png_lidarscan_encoder.cpp
+++ b/ouster_osf/src/png_lidarscan_encoder.cpp
@@ -14,6 +14,20 @@
 #include "ouster/impl/logging.h"
 #include "png_tools.h"
 
+/* Check for the older version of libpng and add missing macros as necessary */
+
+#if (PNG_LIBPNG_VER_MAJOR == 1)
+#if (PNG_LIBPNG_VER_MINOR < 5)
+#define LIBPNG_VERSION_12
+typedef png_bytep png_const_bytep;
+#endif
+#if (PNG_LIBPNG_VER_MINOR < 6)
+typedef png_structp png_const_structrp;
+typedef png_infop png_const_inforp;
+typedef png_bytep png_const_bytep;
+#endif
+#endif
+
 using namespace ouster::sensor;
 
 namespace ouster {


### PR DESCRIPTION
## Summary of Changes
Fix issues in the Github Actions jobs causing them to fail.

Pin Linux version
Pin clang-format version
Pin mypy version
Fix actions failing to use the vcpkg.json
Fix build failure on MacOS 14 due to newer libpng
Fix build failure on Windows due to flatbuffers not being specified as publicly exported headers

## Validation
Ran it.