### PR TITLE
Support click >= 8.2 and relax click pin (#703)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 
 [1.0.0]
 =========
+* Support newer ``click`` versions (>=8.2) in the Python SDK CLI and relax the ``click`` requirement to ``>=8.1.3, <9``.
 * Refactor map export to downsample points as they get added into the map, flushing the pointcloud data to disk as the map accumulates.
 * Added ``ouster::sdk::core::Vector3iHash``, a non-``std`` voxel-index hash with a splitmix64 finalizer that produces good 64-bit dispersion.
 * [CLI/BREAKING] Dropped ``--max-z`` and ``--min-z`` options from ``ouster-cli source ... save (.pcd/.ply)``

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 psutil >=5.9.5, <6
 zeroconf >=0.150.0; python_version >= "3.10"
 zeroconf >=0.131.0; python_version <  "3.10"
-click >=8.1.3, <8.1.8
+click >=8.1.3, <9
 prettytable >= 2.1.0, <3.17.0
 requests >=2.0, <3
 more-itertools >=8.6

--- a/python/src/ouster/cli/plugins/perception.py
+++ b/python/src/ouster/cli/plugins/perception.py
@@ -65,5 +65,5 @@ def source_restore_instance_ids(ctx: SourceCommandContext) -> None:
     ctx.frame_set_iter = detect_iter  # type: ignore[assignment]
 
 
-source.commands['ANY']['detect'] = source_detect
-source.commands['ANY']['restore_instance_ids'] = source_restore_instance_ids
+source.source_commands['ANY']['detect'] = source_detect
+source.source_commands['ANY']['restore_instance_ids'] = source_restore_instance_ids

--- a/python/src/ouster/cli/plugins/source.py
+++ b/python/src/ouster/cli/plugins/source.py
@@ -1912,7 +1912,7 @@ def source_emulate_zones(
     ctx.frame_set_iter = emulate_zones_iter  # type: ignore
 
 
-class SourceMultiCommand(click.MultiCommand):
+class SourceMultiCommand(click.Group):
     """This class implements the ouster-cli source command group.  It uses the
     `io_type` method to determine the source type and map it to the
     available sub commands for that type.
@@ -1920,13 +1920,15 @@ class SourceMultiCommand(click.MultiCommand):
     The source is also added to the click context so that sub commands that use
     @click.pass_context have access to it."""
 
-    commands: MutableMapping[Any, MutableMapping[str, click.Command]]
+    source_commands: MutableMapping[Any, MutableMapping[str, click.Command]]
 
     def __init__(self, *args, **kwargs):
         kwargs['no_args_is_help'] = True
 
         super().__init__(*args, **kwargs)
-        self.commands = {
+        # NOTE: this map is deliberately not stored in click.Group.commands, which
+        # click expects to be a flat mapping of command name to command.
+        self.source_commands = {
             'ANY': {
                 'align': source_align,
                 'clip': source_clip,
@@ -2008,12 +2010,12 @@ class SourceMultiCommand(click.MultiCommand):
                                       OusterIoType.LAS, OusterIoType.LAZ]
 
     def get_supported_source_types(self):
-        return [iotype for iotype in self.commands.keys() if isinstance(iotype, OusterIoType)]
+        return [iotype for iotype in self.source_commands.keys() if isinstance(iotype, OusterIoType)]
 
     def get_source_file_extension_str(self):
         exts = sorted(
             [extension_from_io_type(src_type)
-                for src_type in self.commands.keys() if src_type != 'ANY' and extension_from_io_type(src_type)]
+                for src_type in self.source_commands.keys() if src_type != 'ANY' and extension_from_io_type(src_type)]
         )
         return _join_with_conjunction(exts)
 
@@ -2061,17 +2063,18 @@ class SourceMultiCommand(click.MultiCommand):
         if not source and CliArgs().has_any_of(click_ctx.help_option_names):
             # Build a map from command name to command
             command_to_types: Dict[str, Dict[Any, click.core.Command]] = {}
-            for src_type in self.commands.keys():
-                for command_name in self.commands[src_type].keys():
+            for src_type in self.source_commands.keys():
+                for command_name in self.source_commands[src_type].keys():
+                    command = self.source_commands[src_type][command_name]
                     if command_name not in command_to_types:
                         command_to_types[command_name] = {}
                     if src_type == "ANY":
                         for supported_src_type in self.get_supported_source_types():
                             if supported_src_type in self.non_frame_set_sources:
                                 continue
-                            command_to_types[command_name][supported_src_type] = self.commands[src_type][command_name]
+                            command_to_types[command_name][supported_src_type] = command
                     else:
-                        command_to_types[command_name][src_type] = self.commands[src_type][command_name]
+                        command_to_types[command_name][src_type] = command
 
             # Postfix command name with names of supported source types
             command_to_types_renamed = {}
@@ -2091,8 +2094,8 @@ class SourceMultiCommand(click.MultiCommand):
         try:
             src_type = io_type(source)
             if src_type in self.non_frame_set_sources:
-                return {**self.commands[src_type]}
-            return {**self.commands[src_type], **self.commands["ANY"]}
+                return {**self.source_commands[src_type]}
+            return {**self.source_commands[src_type], **self.source_commands["ANY"]}
         except ValueError as e:  # noqa: F841
             click.echo(click_ctx.get_usage())
             raise click.exceptions.UsageError("Source type expected to be a sensor hostname, "
@@ -2144,7 +2147,14 @@ class SourceMultiCommand(click.MultiCommand):
         """Called when the source command is invoked.
         If called without any args, prints the help.
         Otherwise, the superclass method is called."""
-        if not click_ctx.protected_args:
+        # NOTE: click < 8.2 stores the pending subcommand tokens of a chained
+        # group in Context.protected_args, click >= 8.2 renamed that attribute
+        # to Context._protected_args and deprecated the public one. Look both
+        # up directly to avoid the deprecation warning.
+        pending_args = (click_ctx.__dict__.get("protected_args")
+                        or click_ctx.__dict__.get("_protected_args")
+                        or click_ctx.args)
+        if not pending_args:
             print(self.get_help(click_ctx))
             return
         super().invoke(click_ctx)

--- a/python/src/ouster/cli/plugins/source.py
+++ b/python/src/ouster/cli/plugins/source.py
@@ -2151,9 +2151,12 @@ class SourceMultiCommand(click.Group):
         # group in Context.protected_args, click >= 8.2 renamed that attribute
         # to Context._protected_args and deprecated the public one. Look both
         # up directly to avoid the deprecation warning.
-        pending_args = (click_ctx.__dict__.get("protected_args")
-                        or click_ctx.__dict__.get("_protected_args")
-                        or click_ctx.args)
+        if "protected_args" in click_ctx.__dict__:
+            pending_args = click_ctx.__dict__["protected_args"]
+        elif "_protected_args" in click_ctx.__dict__:
+            pending_args = click_ctx.__dict__["_protected_args"]
+        else:
+            pending_args = click_ctx.args
         if not pending_args:
             print(self.get_help(click_ctx))
             return

--- a/python/src/ouster/cli/plugins/source_localization.py
+++ b/python/src/ouster/cli/plugins/source_localization.py
@@ -64,4 +64,4 @@ def source_localize(ctx: SourceCommandContext, map_path: str, max_range: float, 
     ctx.frame_set_iter = partial(localization_iter, ctx.frame_set_iter)  # type: ignore
 
 
-source.commands['ANY']['localize'] = source_localize
+source.source_commands['ANY']['localize'] = source_localize

--- a/python/src/ouster/cli/plugins/source_mapping.py
+++ b/python/src/ouster/cli/plugins/source_mapping.py
@@ -187,5 +187,5 @@ def save_trajectory(ctx: SourceCommandContext, filename: str, sensor_idx: int, t
     ctx.frame_set_iter = partial(trajectory_dump, ctx.frame_set_iter)  # type: ignore
 
 
-source.commands['ANY']['slam'] = source_slam
-source.commands['ANY']['save_trajectory'] = save_trajectory
+source.source_commands['ANY']['slam'] = source_slam
+source.source_commands['ANY']['save_trajectory'] = save_trajectory

--- a/python/src/ouster/cli/plugins/source_replay.py
+++ b/python/src/ouster/cli/plugins/source_replay.py
@@ -1065,8 +1065,8 @@ def source_sensor_replay(ctx: SourceCommandContext, dockerize: bool, http_addr: 
     process.wait()
 
 
-source.commands[OusterIoType.PCAP]['sensor_replay'] = source_sensor_replay
-source.commands[OusterIoType.BAG]['sensor_replay'] = source_sensor_replay
-source.commands[OusterIoType.MCAP]['sensor_replay'] = source_sensor_replay
-source.commands[OusterIoType.OSF]['sensor_replay'] = source_sensor_replay
-# source.commands[OusterIoType.SENSOR]['sensor_replay'] = source_sensor_replay  # not supported for now
+source.source_commands[OusterIoType.PCAP]['sensor_replay'] = source_sensor_replay
+source.source_commands[OusterIoType.BAG]['sensor_replay'] = source_sensor_replay
+source.source_commands[OusterIoType.MCAP]['sensor_replay'] = source_sensor_replay
+source.source_commands[OusterIoType.OSF]['sensor_replay'] = source_sensor_replay
+# source.source_commands[OusterIoType.SENSOR]['sensor_replay'] = source_sensor_replay  # not supported for now

--- a/python/src/ouster/cli/plugins/source_sensor.py
+++ b/python/src/ouster/cli/plugins/source_sensor.py
@@ -319,12 +319,12 @@ def sensor_live_zones(ctx: SourceCommandContext, click_ctx: click.core.Context, 
         raise click.ClickException(str(e))
 
 
-source.commands[OusterIoType.SENSOR]['config'] = sensor_config
-source.commands[OusterIoType.SENSOR]['userdata'] = sensor_userdata
-source.commands[OusterIoType.SENSOR]['metadata'] = sensor_metadata
-source.commands[OusterIoType.SENSOR]['sensor_info'] = sensor_sensor_info
-source.commands[OusterIoType.SENSOR]['network'] = sensor_network
-source.commands[OusterIoType.SENSOR]['diagnostics'] = sensor_diagnostics
-source.commands[OusterIoType.SENSOR]['restart'] = sensor_restart
-source.commands[OusterIoType.SENSOR]['firmware'] = sensor_firmware
-source.commands[OusterIoType.SENSOR]['live_zones'] = sensor_live_zones
+source.source_commands[OusterIoType.SENSOR]['config'] = sensor_config
+source.source_commands[OusterIoType.SENSOR]['userdata'] = sensor_userdata
+source.source_commands[OusterIoType.SENSOR]['metadata'] = sensor_metadata
+source.source_commands[OusterIoType.SENSOR]['sensor_info'] = sensor_sensor_info
+source.source_commands[OusterIoType.SENSOR]['network'] = sensor_network
+source.source_commands[OusterIoType.SENSOR]['diagnostics'] = sensor_diagnostics
+source.source_commands[OusterIoType.SENSOR]['restart'] = sensor_restart
+source.source_commands[OusterIoType.SENSOR]['firmware'] = sensor_firmware
+source.source_commands[OusterIoType.SENSOR]['live_zones'] = sensor_live_zones

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -17,7 +17,8 @@ from ouster.sdk.viz import Cloud
 # Workaround for Click CliRunner bug (pallets/click#824, fixed in Click 8.3.2
 # via PR #3139). _NamedTextIOWrapper.close() closes the BytesIO buffer it
 # wraps, causing "ValueError: I/O operation on closed file" when background
-# threads outlive cli.main(). Remove this once Click >= 8.3.2 is available.
+# threads outlive cli.main(). Remove this once Click >= 8.3.2 is the minimum
+# supported version.
 if hasattr(_ct, "_NamedTextIOWrapper"):
     _ct._NamedTextIOWrapper.close = lambda self: None  # type: ignore[assignment]
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -18,7 +18,8 @@ from ouster.sdk.viz import Cloud
 # via PR #3139). _NamedTextIOWrapper.close() closes the BytesIO buffer it
 # wraps, causing "ValueError: I/O operation on closed file" when background
 # threads outlive cli.main(). Remove this once Click >= 8.3.2 is available.
-_ct._NamedTextIOWrapper.close = lambda self: None  # type: ignore[assignment]
+if hasattr(_ct, "_NamedTextIOWrapper"):
+    _ct._NamedTextIOWrapper.close = lambda self: None  # type: ignore[assignment]
 
 pytest.register_assert_rewrite('ouster.sdk.core._digest')
 import ouster.sdk.core._digest as digest  # noqa

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -163,11 +163,15 @@ def test_help(runner) -> None:
     assert "Usage: cli util [OPTIONS] COMMAND [ARGS]" in result.output
     assert result.exit_code == 0
 
+    # NOTE: click >= 8.2 exits with code 2 (instead of 0) when a group is
+    # invoked without a subcommand and no_args_is_help is set.
+    no_args_is_help_exit_codes = (0, 2)
+
     result = runner.invoke(core.cli, ['--traceback', 'util'])
-    assert result.exit_code == 0
+    assert result.exit_code in no_args_is_help_exit_codes
 
     result = runner.invoke(core.cli, ['--sdk-log-level', 'debug', 'util'])
-    assert result.exit_code == 0
+    assert result.exit_code in no_args_is_help_exit_codes
 
 
 def test_mapping_help(runner, has_mapping):


### PR DESCRIPTION
## Related Issues & PRs

The `click >=8.1.3, <8.1.8` pin blocks installing the SDK alongside packages that require newer click (e.g. KISS-SLAM). The pin exists because the `source` command group relies on click APIs that changed in 8.2.

## Summary of Changes

- **`click.MultiCommand` → `click.Group`**: `SourceMultiCommand` now derives from `Group` (`MultiCommand` is deprecated and slated for removal in click 9).
- **Stop shadowing `Group.commands`**: the nested source-type → command map moved to `SourceMultiCommand.source_commands`. click 8.4 feeds `self.commands` to `difflib.get_close_matches` for "did you mean" suggestions, which crashed on the `OusterIoType` keys:

  ```
  $ ouster-cli source 127.0.0.1 badcommand
  TypeError: object of type 'IoType' has no len()
  ```

  Plugin registrations (`source_sensor`, `source_mapping`, `source_replay`, `source_localization`, `perception`) were updated accordingly. Note this is a rename of an attribute third-party CLI plugins may use.
- **`Context.protected_args`**: renamed to `Context._protected_args` and deprecated in 8.2; `SourceMultiCommand.invoke` now reads whichever is present before falling back to `ctx.args`, so chained pipelines keep working and no deprecation warning is emitted.
- **Requirement relaxed** to `click >=8.1.3, <9`. Python 3.8/3.9 users still resolve to 8.1.x since click 8.2 requires Python >= 3.10.
- **Tests**: `test_help` accepts click >= 8.2's exit code 2 for `no_args_is_help` groups; the `CliRunner` `_NamedTextIOWrapper` workaround in `conftest.py` is now guarded by `hasattr` (fixed upstream in 8.3.2).

## Validation

CLI test suites (`test_cli`, `test_cli_osf_slice`, `test_plugins`, `test_slam`) pass against click 8.1.3, 8.1.7, 8.1.8, 8.2.0, 8.2.1, 8.3.0 and 8.4.2. flake8 is clean; mypy reports only pre-existing errors.

Fixes https://github.com/ouster-lidar/ouster-sdk/issues/703