### PR TITLE
Allow psutil pip dep up to <8

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-psutil >=5.9.5, <6
+psutil >=5.9.5, <8
 zeroconf >=0.150.0; python_version >= "3.10"
 zeroconf >=0.131.0; python_version <  "3.10"
 click >=8.1.3, <8.1.8


### PR DESCRIPTION
## Related Issues & PRs

The `psutil >=5.9.5, <6` is blocking a required dependency upgrade on my side - and it seems the current upper bound is too strict / not needed.

## Summary of Changes

Allow psutil up to <8

## Validation

No other changes needed. The only psutil APIs used are net_if_addrs(), net_if_stats(), and Process(), all stable and unchanged in psutil 6/7.
scripts/requirements.txt already has an unbounded psutil>=5.9.0, so the <6 cap in python/requirements.txt was the only blocker.